### PR TITLE
Permanent Save Order

### DIFF
--- a/scripts/KneelDiamonds.js
+++ b/scripts/KneelDiamonds.js
@@ -1,12 +1,8 @@
 import { Metals } from "./Metals.js"
 import { DiamondSizes } from "./DiamondSizes.js"
 import {JewelryStyles } from "./JewelryStyles.js"
+import { Orders } from "./Orders.js"
 
-document.addEventListener(
-    "click",
-    (event) => {
-    }
-)
 
 export const KneelDiamonds = () => {
     return `
@@ -33,7 +29,7 @@ export const KneelDiamonds = () => {
 
         <article class="customOrders">
             <h2>Custom Jewelry Orders</h2>
+            ${Orders()}
         </article>
     `
 }
-

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -49,6 +49,10 @@ export const getStyles = () => {
     return [...database.styles]
 }
 
+export const getOrders = () => {
+    return [...database.customOrders]
+}
+
 export const setMetal = (id) => {
     database.orderBuilder.metalId = id 
 }
@@ -59,4 +63,28 @@ export const setSize = (id) => {
 
 export const setStyle = (id) => {
     database.orderBuilder.styleId = id
+}
+
+export const addCustomOrder = () =>  {
+    const newOrder = {...database.newOrder}
+
+    newOrder.id = [...database.customOrders].pop().id + 1
+
+    const today = new Date();
+
+    const month = today.getMonth() + 1;
+
+    const day = today.getDate();
+
+    const time = today.getHours() + ":" + today.getMinutes();
+
+    const currentDate = `${month}/${day}  ${time}`;
+
+    newOrder.timestamp = currentDate
+    
+    database.customOrders.push(newOrder)
+
+    database.orderBuilder = {}
+
+    document.dispatchEvent(new CustomEvent("stateChanged"))
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,6 @@
 import { KneelDiamonds } from "./KneelDiamonds.js"
+import { addCustomOrder } from "./database.js"
+
 
 const mainContainer = document.querySelector("#container")
 
@@ -8,3 +10,13 @@ const renderAllHTML = () => {
 
 renderAllHTML()
 
+
+document.addEventListener(
+    "click",
+    (clivkEvent) => {
+        if (clivkEvent.target.id === "orderButton") {
+            addCustomOrder()
+            renderAllHTML()
+        }
+    }
+)


### PR DESCRIPTION
Added functionality to the Create Custom Order button so that when clicked it saves the current selected options in all three categories as one order. 

STEPS TO TEST:
1. Pull and serve the code
2. Choose an option in all three categories
3. Click the Create Custom Order button
4. Verify a new order appears under Custom Jewelry Orders 